### PR TITLE
Fix: hide cloudinary secret info in settings.py by use heroku config var

### DIFF
--- a/gwachaepah_practice/settings.py
+++ b/gwachaepah_practice/settings.py
@@ -143,9 +143,9 @@ DATABASES['default'].update(db_from_env)
 
 # cloudinary setting
 CLOUDINARY_STORAGE = {
-  'CLOUD_NAME': 'dpthsftz1',
-  'API_KEY': '985276782615182',
-  'API_SECRET': 'tTCgA6S3gXHy9AF4lwjsMCnL0NQ',
+  'CLOUD_NAME': os.environ['CLOUD_NAME'],
+  'API_KEY': os.environ['CLOUD_API_KEY'],
+  'API_SECRET': os.environ['CLOUD_API_SECRET'],
 }
 
 


### PR DESCRIPTION
헤로쿠 서버에서 config var 에 cloudinary storage 관련 secret 정보 환경변수로 넣고
settings.py 에서는 해당 정보 환경변수에서 불러올수 있게 수정했습니다.
확인 부탁드려요