### PR TITLE
Feat: add openApi request command for scheduler

### DIFF
--- a/board/management/commands/scheduler.py
+++ b/board/management/commands/scheduler.py
@@ -1,0 +1,14 @@
+from django.core.management.base import BaseCommand
+from datetime import datetime
+from board.open_api import put_data_to_api_table
+from board.models import OpenApi
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        i = 1
+        date = datetime.now().date()
+        if OpenApi.objects.filter(date=date).first() is None:
+            while i < 5:
+                put_data_to_api_table(date, i * 100)
+                i += 1

--- a/board/views.py
+++ b/board/views.py
@@ -24,12 +24,6 @@ def board(request):
 
 
 def search(request):
-    i = 1
-    date = datetime.now().date()
-    if OpenApi.objects.filter(date=date).first() is None:
-        while i < 5:
-            put_data_to_api_table(date, i * 100)
-            i += 1
     context = {
         # 'open_api_data': OpenApi.objects.all().order_by('id'),
         'open_api_data': OpenApi.objects.filter(Q(item_name__contains='버섯') | Q(kind_name__contains='버섯')).filter(rank='중품', date=date).order_by('id'),


### PR DESCRIPTION
- heroku 스케쥴러를 이용하기 위해 커스텀 커맨드를 만들었다.
- 기존 search 함수에 있는 '테이블에 데이터 넣는 기능'을 갖고 와서 handle 함수에 넣어주었다.
-  `python manage.py [커스텀 커맨드를 넣은 파일명]`을 입력하고 admin에서 확인한 결과, 잘 들어가져 있는 것을 확인할 수 있다.
<img width="820" alt="Screen Shot 2021-10-22 at 4 34 09 PM" src="https://user-images.githubusercontent.com/56112790/138412719-ecc574ae-380e-47c8-b233-d1d8076e21c0.png">
 