### PR TITLE
Refactor: change object create method use bulk_create

### DIFF
--- a/board/open_api.py
+++ b/board/open_api.py
@@ -27,8 +27,8 @@ def put_data_to_api_table(date, category):
     except:
         print("error\n")
         return
-    for item in items:
-        OpenApi.objects.create(
+    open_api_list = [
+        OpenApi(
             item_name=item['item_name'],
             kind_name=item['kind_name'],
             rank=item['rank'],
@@ -37,3 +37,6 @@ def put_data_to_api_table(date, category):
             price=item['dpr1'],
             average_price=item['dpr7'],
         )
+        for item in items
+    ]
+    OpenApi.objects.bulk_create(open_api_list)


### PR DESCRIPTION
- json 데이터의 객체를 하나씩 create 하는 방법은 시간이 너무 많이 걸린다
- 멘토링 결과 이 시간을 줄이는 방법으로 bulk_create 를 추천받아서 수정해보았음
- request 및 db 데이터 업로드 시간이 확연하게 줄어든 것을 확인하였다.