### PR TITLE
Modify: modify post_api to board_api

### DIFF
--- a/board/serializers.py
+++ b/board/serializers.py
@@ -8,10 +8,19 @@ class ProductSerializer(serializers.ModelSerializer):
         fields = '__all__'
 
 
-class PostSerializer(serializers.ModelSerializer):
+class BoardSerializer(serializers.ModelSerializer):
     class Meta:
         model = Post
-        fields = '__all__'
+        fields = [
+            'id',
+            'title',
+            'image1',
+            'view_count',
+            'created_at',
+            'tag',
+            'price',
+            'user_key',
+        ]
 
 
 class CommentSerializer(serializers.ModelSerializer):

--- a/board/views.py
+++ b/board/views.py
@@ -2,7 +2,7 @@ from django.shortcuts import render
 from datetime import datetime
 from .models import Post, Comment, Product, OpenApi
 from django.db.models import Q
-from .serializers import ProductSerializer, PostSerializer, CommentSerializer, SearchSerializer
+from .serializers import ProductSerializer, BoardSerializer, CommentSerializer, SearchSerializer
 from rest_framework import generics, views, response
 
 
@@ -38,9 +38,9 @@ class ProductList(generics.ListAPIView):
     serializer_class = ProductSerializer
 
 
-class PostList(generics.ListAPIView):
+class BoardList(generics.ListAPIView):
     queryset = Post.objects.all()
-    serializer_class = PostSerializer
+    serializer_class = BoardSerializer
 
 
 class CommentList(generics.ListAPIView):

--- a/gwachaepah_practice/urls.py
+++ b/gwachaepah_practice/urls.py
@@ -15,7 +15,7 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path
-from board.views import main, board, search, ProductList, PostList, CommentList, SearchList
+from board.views import main, board, search, ProductList, BoardList, CommentList, SearchList
 from rest_framework.urlpatterns import format_suffix_patterns
 
 
@@ -25,7 +25,7 @@ urlpatterns = [
     path('board/', board, name="board"),
     path('search/', search, name="search"),
     path('product-api/', ProductList.as_view()),
-    path('post-api/', PostList.as_view()),
+    path('board-api/', BoardList.as_view()),
     path('comment-api/<int:pk>/', CommentList.as_view()),
     path('search-api', SearchList.as_view()),
 ]


### PR DESCRIPTION
- board 페이지에서 필요로 하는 데이터만 추린 api 를 생성
- board 페이지에 보낼 데이터이므로 이름을 board-api 로 지정
- 기존의 post-api 와 기능이 겹치고, post-api 가 수정될 예정이므로 post-api 에서 일부 수정하는 방향으로 진행했다.
- 관련된 views.py 와 urls.py 도 수정함