### PR TITLE
Feat: get comment data dynamically

### DIFF
--- a/board/views.py
+++ b/board/views.py
@@ -4,6 +4,7 @@ from .models import Post, Comment, Product, OpenApi
 from django.db.models import Q
 from .serializers import ProductSerializer, BoardSerializer, CommentSerializer, SearchSerializer
 from rest_framework import generics, views, response
+from django.http import Http404
 
 
 def main(request):
@@ -43,9 +44,18 @@ class BoardList(generics.ListAPIView):
     serializer_class = BoardSerializer
 
 
-class CommentList(generics.ListAPIView):
-    queryset = Comment.objects.filter(post_key=8)
-    serializer_class = CommentSerializer
+class CommentList(views.APIView):
+    def get_object(self, pk):
+        try:
+            return Post.objects.get(id=pk)
+        except Post.DoesNotExist:
+            raise Http404
+
+    def get(self, request, pk, format=None):
+        post = self.get_object(pk)
+        comments = Comment.objects.filter(post_key=post)
+        serializer = CommentSerializer(comments, many=True)
+        return response.Response(serializer.data)
 
 
 class SearchList(views.APIView):


### PR DESCRIPTION
- comment data를 동적으로 가져오기 위해, generic을 사용하지 않았다.
- comment serializer에 하나의 포스트와 그 포스트 id에 상응하는 댓글들을 넣었다.
- generic을 사용한 board-api와 사용하지 않은 commet-api를 비교해보면, 보여지는 json 구조가 다르게 보이는 것을 알 수 있다.
<img width="492" alt="Screen Shot 2021-11-04 at 5 50 22 PM" src="https://user-images.githubusercontent.com/56112790/140285998-32022178-cffb-4f38-ba47-94d9f28337ee.png">
<img width="776" alt="Screen Shot 2021-11-04 at 5 50 02 PM" src="https://user-images.githubusercontent.com/56112790/140286010-6a25b514-83b3-4a51-aadc-957b544ddf3f.png">