### PR TITLE
Feat: merge post and comment in post-api

### DIFF
--- a/board/serializers.py
+++ b/board/serializers.py
@@ -23,10 +23,16 @@ class BoardSerializer(serializers.ModelSerializer):
         ]
 
 
-class CommentSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Comment
-        fields = '__all__'
+# class PostSerializer(serializers.ModelSerializer):
+#     class Meta:
+#         model = Post
+#         fields = '__all__'
+
+
+# class CommentSerializer(serializers.ModelSerializer):
+#     class Meta:
+#         model = Comment
+#         fields = '__all__'
 
 
 class SearchSerializer(serializers.ModelSerializer):

--- a/board/views.py
+++ b/board/views.py
@@ -2,9 +2,11 @@ from django.shortcuts import render
 from datetime import datetime
 from .models import Post, Comment, Product, OpenApi
 from django.db.models import Q
-from .serializers import ProductSerializer, BoardSerializer, CommentSerializer, SearchSerializer
+from .serializers import ProductSerializer, BoardSerializer, SearchSerializer
 from rest_framework import generics, views, response
 from django.http import Http404
+from django.core import serializers
+import json
 
 
 def main(request):
@@ -44,7 +46,7 @@ class BoardList(generics.ListAPIView):
     serializer_class = BoardSerializer
 
 
-class CommentList(views.APIView):
+class PostList(views.APIView):
     def get_object(self, pk):
         try:
             return Post.objects.get(id=pk)
@@ -54,8 +56,12 @@ class CommentList(views.APIView):
     def get(self, request, pk, format=None):
         post = self.get_object(pk)
         comments = Comment.objects.filter(post_key=post)
-        serializer = CommentSerializer(comments, many=True)
-        return response.Response(serializer.data)
+        post_list = [post]
+        comments_list = list(comments)
+        joined_list = post_list + comments_list
+        json_str = serializers.serialize('json', joined_list)
+        json_data = json.loads(json_str)
+        return response.Response(json_data)
 
 
 class SearchList(views.APIView):

--- a/gwachaepah_practice/urls.py
+++ b/gwachaepah_practice/urls.py
@@ -15,7 +15,7 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path
-from board.views import main, board, search, ProductList, BoardList, CommentList, SearchList
+from board.views import main, board, search, ProductList, BoardList, PostList, SearchList
 from rest_framework.urlpatterns import format_suffix_patterns
 
 
@@ -26,7 +26,7 @@ urlpatterns = [
     path('search/', search, name="search"),
     path('product-api/', ProductList.as_view()),
     path('board-api/', BoardList.as_view()),
-    path('comment-api/<int:pk>/', CommentList.as_view()),
+    path('post-api/<int:pk>/', PostList.as_view()),
     path('search-api', SearchList.as_view()),
 ]
 


### PR DESCRIPTION
- post 상세보기에서 필요한 api를 제공해야 하는데, 해당 post와 그 포스트에 종속되는 comment를 한번에 보내주기로 했다. #62 
- post와 comment가 각자 다른 모델에 들어가 있는 게 문제였다.
- 첫 번째 방법: `django-rest-multiple-models`를 설치해서, `ObjectMultipleModelAPIView`로 사용해보려고 했다. 그런데 이것도 generics base여서 pk를 가져올 수 없었다. -> 포기
- 최종: multiple queryset을 json으로 serialize 하는 방법을 찾아봤다. -> 성공
<img width="1229" alt="스크린샷 2021-11-03 오후 8 30 48" src="https://user-images.githubusercontent.com/61774034/140296938-d646c2d2-45d5-4be9-b42c-2d442b388e51.png">
