### PR TITLE
Fix: show search param in swagger using querystring

### DIFF
--- a/board/views.py
+++ b/board/views.py
@@ -9,6 +9,8 @@ from django.core import serializers
 import json
 from .forms import PostForm, CommentForm
 from django.views.decorators.http import require_POST
+from drf_yasg import openapi
+from drf_yasg.utils import swagger_auto_schema
 
 
 def main(request):
@@ -145,7 +147,16 @@ class PostList(views.APIView):
 
 
 class SearchList(views.APIView):
-    def get(self, request, search):
-        search_res = OpenApi.objects.filter(Q(item_name__contains=search) | Q(kind_name__contains=search))
+    search_param = openapi.Parameter(
+        'search',
+        openapi.IN_QUERY,
+        description = '여기에 검색어를 넣고 execute 하세요',
+        type = openapi.TYPE_STRING,
+    )
+
+    @swagger_auto_schema(manual_parameters=[search_param])
+    def get(self, request):
+        search_text = request.GET['search']
+        search_res = OpenApi.objects.filter(Q(item_name__contains=search_text) | Q(kind_name__contains=search_text))
         serializer = SearchSerializer(search_res, many=True)
         return response.Response(serializer.data)

--- a/gwachaepah_practice/urls.py
+++ b/gwachaepah_practice/urls.py
@@ -60,5 +60,5 @@ urlpatterns = [
     path('product-api/', ProductList.as_view()),
     path('board-api/', BoardList.as_view()),
     path('post-api/<int:pk>/', PostList.as_view()),
-    path('search-api/<str:search>/', SearchList.as_view()),
+    path('search-api', SearchList.as_view()),
 ]


### PR DESCRIPTION
- `search-api` 에서 검색어를 querystring 으로 받도록 처리함
- 초기엔 이 방법을 사용했을 때 `swagger` 에서 param 입력이 안되는 문제가 있었다
- `swagger_auto_schema` 를 이용해서 `swagger` 에서도 search 파라미터를 입력하여 api 를 받을 수 있도록 수정하였다.