### PR TITLE
Modify: board-api filtering & revert search-api

### DIFF
--- a/board/views.py
+++ b/board/views.py
@@ -2,7 +2,7 @@ from django.shortcuts import render, redirect, get_object_or_404
 from datetime import datetime
 from .models import Post, Comment, Product, OpenApi
 from django.db.models import Q
-from .serializers import ProductSerializer, BoardSerializer
+from .serializers import ProductSerializer, BoardSerializer, SearchSerializer
 from rest_framework import generics, views, response
 from django.http import Http404
 from django.core import serializers
@@ -130,9 +130,32 @@ class ProductList(generics.ListAPIView):
     serializer_class = ProductSerializer
 
 
-class BoardList(generics.ListAPIView):
-    queryset = Post.objects.all().order_by('-id')
-    serializer_class = BoardSerializer
+class BoardList(views.APIView):
+    search_param = openapi.Parameter(
+        'search',
+        openapi.IN_QUERY,
+        description='여기에 검색어를 넣고 execute 하세요',
+        type=openapi.TYPE_STRING,
+    )
+
+    tag_param = openapi.Parameter(
+        'tag',
+        openapi.IN_QUERY,
+        description='소분:0/나눔:1/완료:2 태그를 선택하세요',
+        type=openapi.TYPE_INTEGER
+    )
+
+    @swagger_auto_schema(manual_parameters=[search_param, tag_param])
+    def get(self, request):
+        search_text = request.GET['search']
+        search_res = Post.objects.filter(Q(title__contains=search_text) | Q(content__contains=search_text))
+        try:
+            tag_type = request.GET['tag']
+        except:
+            serializer = BoardSerializer(search_res, many=True)
+            return response.Response(serializer.data)
+        serializer = BoardSerializer(search_res.filter(tag=tag_type), many=True)
+        return response.Response(serializer.data)
 
 
 class PostList(views.APIView):
@@ -164,14 +187,9 @@ class SearchList(views.APIView):
     @swagger_auto_schema(manual_parameters=[search_param])
     def get(self, request):
         search_text = request.GET['search']
-        open_api_res = OpenApi.objects.filter(Q(item_name__contains=search_text) | Q(kind_name__contains=search_text)).order_by('-date')
-        board_res = Post.objects.filter(Q(title__contains=search_text) | Q(content__contains=search_text)).order_by('-id')
-        open_api_list = list(open_api_res)
-        board_list = list(board_res)
-        joined_list = open_api_list + board_list
-        json_str = serializers.serialize('json', joined_list)
-        json_data = json.loads(json_str)
-        return response.Response(json_data)
+        search_res = OpenApi.objects.filter(Q(item_name__contains=search_text) | Q(kind_name__contains=search_text))
+        serializer = SearchSerializer(search_res, many=True)
+        return response.Response(serializer.data)
 
 
 def user_login(request):

--- a/gwachaepah_practice/urls.py
+++ b/gwachaepah_practice/urls.py
@@ -59,7 +59,7 @@ urlpatterns = [
 
     # api
     path('product-api/', ProductList.as_view()),
-    path('board-api/', BoardList.as_view()),
+    path('board-api', BoardList.as_view()),
     path('post-api/<int:pk>/', PostList.as_view()),
     path('search-api', SearchList.as_view()),
 


### PR DESCRIPTION
- 프론트 @deftones88 의 요청으로 `search-api`를 이전처럼 검색한 수확물 정보만 보내지게 바꿨다.
- 역시 프론트 @deftones88 의 요청으로 `board-api`에서 검색한 내용과 태그에 따라 분류해서 보냈다.