### PR TITLE
Modify: modify timefield format & fetch post, comment serializer

### DIFF
--- a/board/serializers.py
+++ b/board/serializers.py
@@ -1,4 +1,4 @@
-from .models import Product, Post, OpenApi
+from .models import Product, Post, Comment, OpenApi
 from rest_framework import serializers
 
 
@@ -13,6 +13,7 @@ class ProductSerializer(serializers.ModelSerializer):
 
 
 class BoardSerializer(serializers.ModelSerializer):
+    created_at = serializers.DateTimeField(format="%Y.%m.%d %H:%M")
     class Meta:
         model = Post
         fields = [
@@ -27,7 +28,29 @@ class BoardSerializer(serializers.ModelSerializer):
         ]
 
 
+class PostSerializer(serializers.ModelSerializer):
+    created_at = serializers.DateTimeField(format="%Y.%m.%d %H:%M")
+    updated_at = serializers.DateTimeField(format="%Y.%m.%d %H:%M")
+    class Meta:
+        model = Post
+        fields = '__all__'
+
+
+class CommentSerializer(serializers.ModelSerializer):
+    created_at = serializers.DateTimeField(format="%Y.%m.%d %H:%M")
+    updated_at = serializers.DateTimeField(format="%Y.%m.%d %H:%M")
+    class Meta:
+        model = Comment
+        fields = '__all__'
+
+
+class PostDetailSerializer(serializers.Serializer):
+    post = PostSerializer()
+    comments = CommentSerializer(many=True)
+
+
 class SearchSerializer(serializers.ModelSerializer):
+    created_at = serializers.DateTimeField(format="%Y.%m.%d %H:%M")
     class Meta:
         model = OpenApi
         fields = '__all__'


### PR DESCRIPTION
- 프론트 @deftones88 의 요청으로 모든 api 에 제공되는 time 정보를 format %Y.%m.%d %H:%M 으로 변경했다.
- 이 과정에서 post-api 의 경우에도 수정하기 위해서 멘토링에서 배운 serializer 중첩하는 방법에 대해서 적용해보았다
- 그 결과 post 와 comment 가 각각의 이름으로 분리되어 데이터가 요청되는 것 까지 적용된 것을 확인함