### PR TITLE
Delete: DateTimeField in serializer

### DIFF
--- a/board/serializers.py
+++ b/board/serializers.py
@@ -13,7 +13,6 @@ class ProductSerializer(serializers.ModelSerializer):
 
 
 class BoardSerializer(serializers.ModelSerializer):
-    created_at = serializers.DateTimeField(format="%Y.%m.%d %H:%M")
     class Meta:
         model = Post
         fields = [
@@ -29,16 +28,12 @@ class BoardSerializer(serializers.ModelSerializer):
 
 
 class PostSerializer(serializers.ModelSerializer):
-    # created_at = serializers.DateTimeField(format="%Y.%m.%d %H:%M")
-    # updated_at = serializers.DateTimeField(format="%Y.%m.%d %H:%M")
     class Meta:
         model = Post
         fields = '__all__'
 
 
 class CommentSerializer(serializers.ModelSerializer):
-    # created_at = serializers.DateTimeField(format="%Y.%m.%d %H:%M")
-    # updated_at = serializers.DateTimeField(format="%Y.%m.%d %H:%M")
     class Meta:
         model = Comment
         fields = '__all__'
@@ -50,7 +45,6 @@ class PostDetailSerializer(serializers.Serializer):
 
 
 class SearchSerializer(serializers.ModelSerializer):
-    created_at = serializers.DateTimeField(format="%Y.%m.%d %H:%M")
     class Meta:
         model = OpenApi
         fields = '__all__'


### PR DESCRIPTION
- `CommentSerializer`, `PostDetailSeriaiizer` 에서 DateTimeField로 날짜 포맷을 바꾸니, api에서 `POST`하면 시간이 자동으로 생성되지 않아 에러가 났다.
- model이나 form을 바꿔주는 경우도 생각했지만, 일단 프론트에서 가공하는걸로 결정이 났다.