### PR TITLE
Ylee random user create post and comment

### DIFF
--- a/board/views.py
+++ b/board/views.py
@@ -178,10 +178,11 @@ class BoardList(views.APIView):
     def post(self, request):
         # 임시로 프론트가 새글쓰기 가능하도록 임의의 유저를 넣어준다
         try:
-            user = User.objects.get(username=request.data.user_key)
+            user = User.objects.get(pk=request.data["user_key"])
         except:
-            user = User.objects.all().order_by('?')[0]
-        request.data.user = user
+            pks = User.objects.values_list('pk', flat=True)
+            user = User.objects.get(pk=choice(pks))
+        request.data["user_key"] = user.pk
         # 나중에 여기 위에 까지 지우기
         serializer = BoardSerializer(data=request.data)
         if serializer.is_valid():

--- a/board/views.py
+++ b/board/views.py
@@ -13,6 +13,7 @@ from drf_yasg.utils import swagger_auto_schema
 from django.contrib.auth import authenticate, login, logout, models
 from django.contrib.auth.decorators import login_required
 from collections import namedtuple
+from random import choice
 
 
 def main(request):
@@ -136,6 +137,9 @@ class ProductList(generics.ListAPIView):
 
 
 class BoardList(views.APIView):
+    queryset = Post.objects.all()
+    serializer_class = PostSerializer
+
     search_param = openapi.Parameter(
         'search',
         openapi.IN_QUERY,
@@ -174,9 +178,9 @@ class BoardList(views.APIView):
     def post(self, request):
         # 임시로 프론트가 새글쓰기 가능하도록 임의의 유저를 넣어준다
         try:
-            user = User.objects.get(username=request.data.user).pk
+            user = User.objects.get(username=request.data.user_key)
         except:
-            user = User.objects.order_by('?')[0].pk
+            user = User.objects.all().order_by('?')[0]
         request.data.user = user
         # 나중에 여기 위에 까지 지우기
         serializer = BoardSerializer(data=request.data)
@@ -230,13 +234,14 @@ class CommentList(generics.GenericAPIView):
         serializer = CommentSerializer(comments, many=True)
         return response.Response(serializer.data)
 
-    def post(self, request):
+    def post(self, request, pk):
         # 임시로 프론트가 새글쓰기 가능하도록 임의의 유저를 넣어준다
         try:
-            user = User.objects.get(username=request.data.user).pk
+            user = User.objects.get(pk=request.data["user_key"])
         except:
-            user = User.objects.order_by('?')[0].pk
-        request.data.user = user
+            pks = User.objects.values_list('pk', flat=True)
+            user = User.objects.get(pk=choice(pks))
+        request.data["user_key"] = user.pk
         # 나중에 여기 위에 까지 지우기
         serializer = CommentSerializer(data=request.data)
         if serializer.is_valid():


### PR DESCRIPTION
- POST 타입으로 HTTP 를 통해 프론트에서 들어오는 request 에는 method = "post" 와 data = {항목들} 이 json 으로 들어와야한다.
- 일단 board-api 에서 post 부분에는 data 를 받을 수 없는 상태이다.
- 그래서 comment-api 의 post 부분에서 data 가 어떻게 들어와야하고, 그 data 를 어떻게 다뤄야하는지 테스트해보았다.
- 우선 comment-api 에서 post 될 때에는 comment 내용과, comment 가 달릴 post_key, 그리고 comment 를 작성한 user_key 가 들어온다
- 이 세 데이터는 dict 타입으로 오기때문에 user_key의 value 를 받으려면 request.data["user_key"] 형식으로 가져와야한다. (request.data.user_key 로 가져오려다가 에러남)
- 이 때, post_key 와 user_key 는 int 타입으로 pk 에 해당한다
- User 테이블에서 username 이 곧 pk 역할을 하는 것으로 알았는데, pk 는 int 타입이고, username 은 str 타입이다.
- 따라서 data 에 들어온 user_key 에 해당하는 User object 가 있는지 확인하려면 User.objects.get(pk=user_key_value) 로 찾아야한다.
- try 를 통해 data 에 들어온 user_key 에 해당하는 User 가 존재하는지 확인하고, 존재한다면 그 값을 그대로 두고 존재하지 않는 경우 User 테이블에 있는 항목들 중에서 임의의 key 를 가져와 등록되도록 처리했다.
- 일단 로컬 스웨거에서는 제대로 작동하는데, 실제로 그러할지 확신이 들지 않아서 일단 풀리퀘 후 머지해본다... 