### PR TITLE
Modify: devide board-api by role

### DIFF
--- a/board/models.py
+++ b/board/models.py
@@ -15,6 +15,7 @@ class Profile(models.Model):
     )
     local = models.PositiveIntegerField(default=0)
 
+
 @receiver(post_save, sender=User)
 def update_user_profile(sender, instance, created, **kwargs):
     if created:

--- a/gwachaepah_practice/settings.py
+++ b/gwachaepah_practice/settings.py
@@ -156,7 +156,7 @@ REST_FRAMEWORK = {
         'rest_framework_simplejwt.authentication.JWTAuthentication',
     ],
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
-    'PAGE_SIZE': 12
+    'PAGE_SIZE': 2
 }
 
 # CORS_ALLOWED_ORIGINS = [

--- a/gwachaepah_practice/urls.py
+++ b/gwachaepah_practice/urls.py
@@ -17,7 +17,7 @@ from django.contrib import admin
 from django.urls import path
 from board.views import main, board, show, search, new, create, edit, update, delete,\
     comment_create, comment_update, comment_delete,\
-    ProductList, BoardList, PostCommentList, PostList, CommentList, CommentDetailList, SearchList,\
+    ProductList, BoardSearchList, BoardList, PostCommentList, PostList, CommentList, CommentDetailList, SearchList,\
     user_login, user_logout, register, user_register, TestView
 from rest_framework import permissions
 from drf_yasg.views import get_schema_view
@@ -63,11 +63,12 @@ urlpatterns = [
 
     # api
     path('product-api/', ProductList.as_view()),
-    path('board-api', BoardList.as_view()),
-    path('post_comment-api/<int:pk>/', PostCommentList.as_view()),
-    path('post-api/<int:pk>/', PostList.as_view()),
-    path('comment-api/<int:pk>/', CommentList.as_view()),
-    path('comment_detail-api/<int:pk>/', CommentDetailList.as_view()),
+    path('board-api', BoardSearchList.as_view()), # 쿼리 스트링 받아서 필터링
+    path('board-api/', BoardList.as_view()), # 전체 보드 데이터 + 페이지네이션 get, 새 글 작성 post
+    path('post_comment-api/<int:pk>/', PostCommentList.as_view()), # 포스트 페이지에서 보일 특정 포스트 + 코멘트 리스트 get
+    path('post-api/<int:pk>/', PostList.as_view()), # 특정 포스트의 put(+patch) delete
+    path('comment-api/', CommentList.as_view()), # 특정 포스트 pk 에 코멘트를 post
+    path('comment-api/<int:pk>/', CommentDetailList.as_view()), # 특정 코멘트 pk 의 코멘트를 put get delete
     path('search-api', SearchList.as_view()),
 
     # user


### PR DESCRIPTION
- 이전에는 board-api 를 검색어, 태그에 따라서 필터링 될 수 있게 query string 을 받을 수 있는 형태로 만들었다.
- 이 떄 api url 이 `~/board-api` 인데, 뒤에 `/` 가 없어서 전체 데이터 GET 기능과 pagination 이 안되는 문제가 발생했다(GET 기능은 프론트가 로컬에서 테스트할 때 발생한 문제. swagger 나 api url 에서는 문제가 없었다. 원인을 아직 확실히 모르는 상태임)
- 이를 위해 `~/board-api?querystring` 형태의 api 와 `~/board-api/` 형태의 api 를 분리하기로 했다
- 동시에 view 타입도 generic 으로 변경했다
- `~/board-api` url 은 board 페이지에 검색어와 태그에 따라 필터링되는 보드 데이터를 GET 하는 기능을 하고, (class : BoardSearchList)
- `~/board-api/` url 은 board 페이지에 띄워질 전체 보드 데이터 GET 기능과, 새 게시글을 작성하는 POST 기능을 한다(class : BoardList)
- BoardList 함수에서 `def post` 함수는 현재 프론트에서 유저키를 임의로 넣어도 작동하도록 하기 위해서 넣은 함수로, 후에 삭제한다.
- swagger 에서 파일 업로드가 안되는 문제를 발견해서 MultiPartParser 를 추가했다.