### PR TITLE
Modify: resetting update func in post-api & comment-api

### DIFF
--- a/board/views.py
+++ b/board/views.py
@@ -138,6 +138,9 @@ class ProductList(generics.ListAPIView):
 
 
 class BoardSearchList(generics.ListAPIView):
+    queryset = Post.objects.all()
+    serializer_class = BoardSerializer
+
     search_param = openapi.Parameter(
         'search',
         openapi.IN_QUERY,
@@ -219,9 +222,9 @@ class PostList(generics.RetrieveUpdateDestroyAPIView):
     serializer_class = PostSerializer
     parser_classes = (MultiPartParser,)
 
-    # def update(self, request, *args, **kwargs):
-    #     kwargs['partial'] = True
-    #     return super().update(request, *args, **kwargs)
+    def update(self, request, *args, **kwargs):
+        kwargs['partial'] = True
+        return super().update(request, *args, **kwargs)
 
 
 class CommentList(generics.CreateAPIView):
@@ -248,6 +251,10 @@ class CommentList(generics.CreateAPIView):
 class CommentDetailList(generics.RetrieveUpdateDestroyAPIView):
     queryset = Comment.objects.all()
     serializer_class = CommentSerializer
+
+    def update(self, request, *args, **kwargs):
+        kwargs['partial'] = True
+        return super().update(request, *args, **kwargs)
 
 
 class SearchList(views.APIView):


### PR DESCRIPTION
- `views.py`의 `PostList`와 `CommentList`에 put을 fetch처럼 쓸 수 있는 update func 를 다시 올렸다.
- `BoardSearchList`에 오류가 있어 `queryset`과 `serializer_class`를 다시 설정해주었다.
![스크린샷 2021-11-12 오후 9 02 09](https://user-images.githubusercontent.com/70003380/141464087-ae2bcf1c-d418-4579-9f0c-8f24497bd8d0.png)
