### PR TITLE
Modify: add MultiPartParser into CommentDetailList & PostList

### DIFF
--- a/board/views.py
+++ b/board/views.py
@@ -251,6 +251,7 @@ class CommentList(generics.CreateAPIView):
 class CommentDetailList(generics.RetrieveUpdateDestroyAPIView):
     queryset = Comment.objects.all()
     serializer_class = CommentSerializer
+    parser_classes = (MultiPartParser,)
 
     def update(self, request, *args, **kwargs):
         kwargs['partial'] = True


### PR DESCRIPTION
- `CommentDetailList`에 `MultiPartParser`를 넣어주었다
- `PostList`에는 `MultiPartParser`가 이전에도 있었기 때문에 따로 넣어주지는 않았고, 프론트에 관련 부분 코드 수정을 요청하였다.