### PR TITLE
Modify: ordering post in board

### DIFF
--- a/board/views.py
+++ b/board/views.py
@@ -178,7 +178,7 @@ class BoardSearchList(generics.ListAPIView):
 
 
 class BoardList(generics.ListCreateAPIView):
-    queryset = Post.objects.all()
+    queryset = Post.objects.all().order_by('-id')
     serializer_class = PostSerializer
     parser_classes = (MultiPartParser,)
 


### PR DESCRIPTION
- 프론트에서 테스트를 할 때 board 페이지에서 post들이 정렬되어 나타나지 않는다.
- 최근에 게시된 글이 가장 먼저 나타나게(맨 앞에) 정렬했다.