### PR TITLE
Fix: delete update function in PUT

### DIFF
--- a/board/views.py
+++ b/board/views.py
@@ -223,10 +223,6 @@ class PostList(generics.RetrieveUpdateDestroyAPIView):
     serializer_class = PostSerializer
     parser_classes = (MultiPartParser,)
 
-    def update(self, request, *args, **kwargs):
-        kwargs['partial'] = True
-        return super().update(request, *args, **kwargs)
-
 
 class CommentList(generics.CreateAPIView):
     queryset = Comment.objects.all()
@@ -253,10 +249,6 @@ class CommentDetailList(generics.RetrieveUpdateDestroyAPIView):
     queryset = Comment.objects.all()
     serializer_class = CommentSerializer
     # parser_classes = (MultiPartParser,)
-
-    def update(self, request, *args, **kwargs):
-        kwargs['partial'] = True
-        return super().update(request, *args, **kwargs)
 
 
 class SearchList(views.APIView):


### PR DESCRIPTION
- `PUT`을 `PATCH`처럼 쓰고 있었는데, 멘토링에서 그렇게 쓰는 것은 의미가 없다고 했다.
- 되돌려놓기 위해 `PUT`에서 부분적으로 수정할 수 있는 함수인 `update()`를 오버라이딩 헤서 작성했던 부분을 뺐다.