### PR TITLE
Feat: add read_only_fields in serializer

### DIFF
--- a/board/serializers.py
+++ b/board/serializers.py
@@ -11,6 +11,12 @@ class ProductSerializer(serializers.ModelSerializer):
             'name',
             'image',
         ]
+        read_only_fields = [
+            'id',
+            'name',
+            'image',
+            'month',
+        ]
 
 
 class BoardSerializer(serializers.ModelSerializer):
@@ -26,18 +32,42 @@ class BoardSerializer(serializers.ModelSerializer):
             'price',
             'user_key',
         ]
+        read_only_fields = [
+            'id',
+            'title',
+            'image1',
+            'view_count',
+            'created_at',
+            'tag',
+            'price',
+            'user_key',
+        ]
 
 
 class PostSerializer(serializers.ModelSerializer):
     class Meta:
         model = Post
         fields = '__all__'
+        read_only_fields = [
+            'id',
+            'view_count',
+            'created_at',
+            'updated_at',
+            'user_key',
+        ]
 
 
 class CommentSerializer(serializers.ModelSerializer):
     class Meta:
         model = Comment
         fields = '__all__'
+        read_only_fields = [
+            'id',
+            'created_at',
+            'updated_at',
+            'post_key',
+            'user_key',
+        ]
 
 
 class PostDetailSerializer(serializers.Serializer):
@@ -49,6 +79,16 @@ class SearchSerializer(serializers.ModelSerializer):
     class Meta:
         model = OpenApi
         fields = '__all__'
+        read_only_fields = [
+            'item_name',
+            'kind_name',
+            'rank',
+            'unit',
+            'date',
+            'price',
+            'average_price',
+            'created_at',
+        ]
 
 
 class UserSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
- `serializers.py`에서 `read_only_fields`를 추가했다.
- `fields`에 있는 정보들 중 `GET`할 때 말고는 필요없는 정보들을 `read_only_fields`에 넣으면 속도가 빨라진다.
- `read_only_fields`에 있는 정보들은 swagger에서 `PUT`이나 `PATCH`를 할 때 나타나지 않는다.