### PR TITLE
Fix: divide serializer for POST

### DIFF
--- a/board/serializers.py
+++ b/board/serializers.py
@@ -58,6 +58,12 @@ class PostSerializer(serializers.ModelSerializer):
         ]
 
 
+class PostCreateSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Post
+        fields = '__all__'
+
+
 class CommentSerializer(serializers.ModelSerializer):
     class Meta:
         model = Comment
@@ -69,6 +75,12 @@ class CommentSerializer(serializers.ModelSerializer):
             'post_key',
             'user_key',
         ]
+
+
+class CommentCreateSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Comment
+        fields = '__all__'
 
 
 class PostDetailSerializer(serializers.Serializer):

--- a/gwachaepah_practice/urls.py
+++ b/gwachaepah_practice/urls.py
@@ -19,7 +19,7 @@ from board.views import main, board, show, search, new, create, edit, update, de
     comment_create, comment_update, comment_delete,\
     ProductList, BoardSearchList, BoardList, PostCommentList, PostList, CommentList, \
     CommentDetailList, SearchList, user_login, user_logout, register, user_register, \
-    UserCheck, MyTokenObtainPairView
+    UserCheck, MyTokenObtainPairView, PostCreateView
 from rest_framework import permissions
 from drf_yasg.views import get_schema_view
 from drf_yasg import openapi
@@ -65,11 +65,13 @@ urlpatterns = [
     # api
     path('product-api/', ProductList.as_view()),
     path('board-api', BoardSearchList.as_view()), # 쿼리 스트링 받아서 필터링
-    path('board-api/', BoardList.as_view()), # 전체 보드 데이터 + 페이지네이션 get, 새 글 작성 post
+    path('board-api/', BoardList.as_view()), # 전체 보드 데이터 + 페이지네이션 get
     path('post_comment-api/<int:pk>/', PostCommentList.as_view()), # 포스트 페이지에서 보일 특정 포스트 + 코멘트 리스트 get
+    path('post-api/', PostCreateView.as_view()), # post POST
     path('post-api/<int:pk>/', PostList.as_view()), # 특정 포스트의 put(+patch) delete
-    path('comment-api/', CommentList.as_view()), # 특정 포스트 pk 에 코멘트를 post
-    path('comment-api/<int:pk>/', CommentDetailList.as_view()), # 특정 코멘트 pk 의 코멘트를 put get delete
+    path('comment-api/', CommentList.as_view()), # 특정 포스트 pk 에 comment POST
+    # 특정 post의 모든 comment를 보고 싶은 api
+    path('comment-api/<int:pk>/', CommentDetailList.as_view()), # 특정 comment pk 의 comment put get delete
     path('search-api', SearchList.as_view()),
 
     # user


### PR DESCRIPTION
- board-api POST에서 500 에러가 뜨는 현상이 있었다.
- POST 할 때는, `read_only_fields` 가 필요하지 않으므로 기존 `PostSerializer`와 `CommentSerializer`에서 POST 하는 기능만 따로 serializer를 만들어 주었다.
- 나눠진 serializer에 따라 views.py에서도 POST 하는 함수만 따로 만들어 주었는데, post-api POST에는 이미지가 들어가므로 `parser_classes = (MultiPartParser,)` 를 추가하였다.
- 기존에는 board-api에 post를 POST 하는 기능이 있었는데, 연관성과 통일성을 위해 `post-api/` 로 바꾸었다.
