### PR TITLE
Modify: divide comment list and detail

### DIFF
--- a/board/views.py
+++ b/board/views.py
@@ -184,7 +184,10 @@ class BoardList(generics.ListAPIView):
     serializer_class = BoardSerializer
 
 
-class PostCommentList(views.APIView):
+class CommentList(generics.ListAPIView):
+    queryset = Comment.objects.all()
+    serializer_class = CommentSerializer
+
     def get_object(self, pk):
         try:
             return Post.objects.get(id=pk)
@@ -194,12 +197,7 @@ class PostCommentList(views.APIView):
     def get(self, request, pk):
         post = self.get_object(pk)
         comments = Comment.objects.filter(post_key=post).order_by('id')
-        Detail = namedtuple('Detail', ('post', 'comments'))
-        detail = Detail(
-            post=post,
-            comments=comments,
-        )
-        serializer = PostDetailSerializer(detail)
+        serializer = CommentSerializer(comments, many=True)
         return response.Response(serializer.data)
 
 
@@ -230,7 +228,7 @@ class PostCreateView(generics.CreateAPIView):
     # 나중에 여기 위에 까지 지우기
 
 
-class CommentList(generics.CreateAPIView):
+class CommentCreateView(generics.CreateAPIView):
     queryset = Comment.objects.all()
     serializer_class = CommentCreateSerializer
 
@@ -326,22 +324,3 @@ def user_register(request):
 
 class MyTokenObtainPairView(TokenObtainPairView):
     serializer_class = MyTokenObtainPairSerializer
-
-
-class PostCommentList(views.APIView):
-    def get_object(self, pk):
-        try:
-            return Post.objects.get(id=pk)
-        except Post.DoesNotExist:
-            raise Http404
-
-    def get(self, request, pk):
-        post = self.get_object(pk)
-        comments = Comment.objects.filter(post_key=post).order_by('id')
-        Detail = namedtuple('Detail', ('post', 'comments'))
-        detail = Detail(
-            post=post,
-            comments=comments,
-        )
-        serializer = PostDetailSerializer(detail)
-        return response.Response(serializer.data)

--- a/gwachaepah_practice/urls.py
+++ b/gwachaepah_practice/urls.py
@@ -17,7 +17,7 @@ from django.contrib import admin
 from django.urls import path
 from board.views import main, board, show, search, new, create, edit, update, delete,\
     comment_create, comment_update, comment_delete,\
-    ProductList, BoardSearchList, BoardList, PostCommentList, PostList, CommentList, \
+    ProductList, BoardSearchList, BoardList, CommentList, PostList, CommentCreateView, \
     CommentDetailList, SearchList, user_login, user_logout, register, user_register, \
     UserCheck, MyTokenObtainPairView, PostCreateView
 from rest_framework import permissions
@@ -66,10 +66,10 @@ urlpatterns = [
     path('product-api/', ProductList.as_view()),
     path('board-api', BoardSearchList.as_view()), # 쿼리 스트링 받아서 필터링
     path('board-api/', BoardList.as_view()), # 전체 보드 데이터 + 페이지네이션 get
-    path('post_comment-api/<int:pk>/', PostCommentList.as_view()), # 포스트 페이지에서 보일 특정 포스트 + 코멘트 리스트 get
     path('post-api/', PostCreateView.as_view()), # post POST
     path('post-api/<int:pk>/', PostList.as_view()), # 특정 포스트의 put(+patch) delete
-    path('comment-api/', CommentList.as_view()), # 특정 포스트 pk 에 comment POST
+    path('comment/api/list/<int:pk>/', CommentList.as_view()), # 특정 post(pk)의 comments GET
+    path('comment-api/', CommentCreateView.as_view()), # 특정 포스트 pk 에 comment POST
     # 특정 post의 모든 comment를 보고 싶은 api
     path('comment-api/<int:pk>/', CommentDetailList.as_view()), # 특정 comment pk 의 comment put get delete
     path('search-api', SearchList.as_view()),


### PR DESCRIPTION
- @deftones88 의 요청: 하나의 post에 있는 comment들 불러오는 api 필요하다.
- post 하나와 그에 대한 comment들을 보내주는 api를 post 없이 해당 post의 comment들만 보내주는 api로 변경했다.
- 나중에 바꾸겠지만, 일관성과 통일성과 가독성을 위해 api 관련 url을 바꿨다. -> '[뭔지]/api/[구체적]/'