### PR TITLE
Modify: board search case exclude tag=2, include pagination

### DIFF
--- a/board/views.py
+++ b/board/views.py
@@ -168,13 +168,19 @@ class BoardSearchList(generics.ListAPIView):
         try:
             tag_type = request.GET['tag']
         except:
-            return search_res
+            return search_res.exclude(tag=2)
         return search_res.filter(tag=tag_type)
 
     @swagger_auto_schema(manual_parameters=[search_param, tag_param])
     def get(self, request, *args, **kwargs):
         search_res = self.get_search(request)
         result = self.get_tag(request, search_res)
+        page = self.paginate_queryset(result)
+
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+
         serializer = BoardSerializer(result, many=True)
         return response.Response(serializer.data)
 


### PR DESCRIPTION
- 보드 페이지에서 검색어가 들어오거나 소분/나눔/완료 태그별로 필터링될 때의 수정 (~board/api url)
- 검색어만 들어온 경우 완료(tag=2) 를 제외하고 보여지도록 한다
- 검색 또는 태그 필터링이 되는 경우에도 페이지네이션 되도록 한다