### PR TITLE
Fix: import serializers from .

### DIFF
--- a/board/views.py
+++ b/board/views.py
@@ -19,7 +19,7 @@ from drf_yasg.utils import swagger_auto_schema
 from .models import Post, Comment, Product, OpenApi
 from .forms import PostForm, CommentForm, LoginForm, RegisterForm
 
-import serializers as ser
+from . import serializers as ser
 
 
 def main(request):


### PR DESCRIPTION
- #123 에서 serializers를 줄이는 과정에서 `from .`을 붙이지 않아, 프론트에서 `ModuleNotFoundError`가 떠서, 수정했다.