### PR TITLE
Modify: add comment cnt and username data when post get request

### DIFF
--- a/board/serializers.py
+++ b/board/serializers.py
@@ -21,6 +21,20 @@ class ProductSerializer(serializers.ModelSerializer):
 
 
 class BoardSerializer(serializers.ModelSerializer):
+    comment_cnt = serializers.SerializerMethodField()
+    username = serializers.SerializerMethodField()
+
+    def get_comment_cnt(self, obj):
+        pk = obj.id
+        queryset = Comment.objects.filter(post_key=pk)
+        comment_cnt = len(queryset)
+        return comment_cnt
+
+    def get_username(self, obj):
+        user = obj.user_key
+        username = user.username
+        return username
+
     class Meta:
         model = Post
         fields = [
@@ -32,6 +46,8 @@ class BoardSerializer(serializers.ModelSerializer):
             'tag',
             'price',
             'user_key',
+            'username',
+            'comment_cnt',
         ]
         read_only_fields = [
             'id',
@@ -42,10 +58,35 @@ class BoardSerializer(serializers.ModelSerializer):
             'tag',
             'price',
             'user_key',
+            'username',
+            'comment_cnt',
         ]
 
 
+class MyTokenObtainPairSerializer(TokenObtainPairSerializer):
+    def validate(self, attrs):
+        data = super().validate(attrs)
+        data['pk'] = self.user.pk
+        data['username'] = self.user.username
+        data['region'] = self.user.profile.region
+        return data
+
+
 class PostSerializer(serializers.ModelSerializer):
+    comment_cnt = serializers.SerializerMethodField()
+    username = serializers.SerializerMethodField()
+
+    def get_comment_cnt(self, obj):
+        pk = obj.id
+        queryset = Comment.objects.filter(post_key=pk)
+        comment_cnt = len(queryset)
+        return comment_cnt
+
+    def get_username(self, obj):
+        user = obj.user_key
+        username = user.username
+        return username
+
     class Meta:
         model = Post
         fields = '__all__'
@@ -55,6 +96,8 @@ class PostSerializer(serializers.ModelSerializer):
             'created_at',
             'updated_at',
             'user_key',
+            'username',
+            'comment_cnt',
         ]
 
 

--- a/board/serializers.py
+++ b/board/serializers.py
@@ -63,15 +63,6 @@ class BoardSerializer(serializers.ModelSerializer):
         ]
 
 
-class MyTokenObtainPairSerializer(TokenObtainPairSerializer):
-    def validate(self, attrs):
-        data = super().validate(attrs)
-        data['pk'] = self.user.pk
-        data['username'] = self.user.username
-        data['region'] = self.user.profile.region
-        return data
-
-
 class PostSerializer(serializers.ModelSerializer):
     comment_cnt = serializers.SerializerMethodField()
     username = serializers.SerializerMethodField()

--- a/board/views.py
+++ b/board/views.py
@@ -185,12 +185,8 @@ class BoardSearchList(generics.ListAPIView):
             return self.get_paginated_response(serializer.data)
 
         serializer = ser.BoardSerializer(result, many=True)
+        print(serializer.data)
         return response.Response(serializer.data)
-
-
-class BoardList(generics.ListAPIView):
-    queryset = Post.objects.all().exclude(tag=2).order_by('-id')
-    serializer_class = ser.BoardSerializer
 
 
 class CommentList(generics.ListAPIView):
@@ -221,41 +217,10 @@ class PostCreateView(generics.CreateAPIView):
     serializer_class = ser.PostCreateSerializer
     parser_classes = (MultiPartParser,)
 
-    # 임시로 프론트가 새글쓰기 가능하도록 임의의 유저를 넣어준다
-    # def post(self, request, *args, **kwargs):
-    #     try:
-    #         user = User.objects.get(pk=request.data["user_key"])
-    #     except:
-    #         pks = User.objects.values_list('pk', flat=True)
-    #         user = User.objects.get(pk=choice(pks))
-    #     request.data["user_key"] = user.pk
-    #     serializer = PostCreateSerializer(data=request.data)
-    #     if serializer.is_valid():
-    #         serializer.save()
-    #         return response.Response(serializer.data, status=status.HTTP_201_CREATED)
-    #     return response.Response(serializer.errors, status=status.HTTP_418_IM_A_TEAPOT)
-    # 나중에 여기 위에 까지 지우기
-
 
 class CommentCreateView(generics.CreateAPIView):
     queryset = Comment.objects.all()
     serializer_class = ser.CommentCreateSerializer
-
-    # 임시로 프론트가 새글쓰기 가능하도록 임의의 유저를 넣어준다
-    def post(self, request):
-        try:
-            user = User.objects.get(pk=request.data["user_key"])
-        except:
-            pks = User.objects.values_list('pk', flat=True)
-            user = User.objects.get(pk=choice(pks))
-        request.data["user_key"] = user.pk
-
-        serializer = ser.CommentCreateSerializer(data=request.data)
-        if serializer.is_valid():
-            serializer.save()
-            return response.Response(serializer.data, status=status.HTTP_201_CREATED)
-        return response.Response(serializer.errors, status=status.HTTP_418_IM_A_TEAPOT)
-        # 나중에 여기 위에 까지 지우기
 
 
 class CommentDetailView(generics.RetrieveUpdateDestroyAPIView):

--- a/board/views.py
+++ b/board/views.py
@@ -185,7 +185,6 @@ class BoardSearchList(generics.ListAPIView):
             return self.get_paginated_response(serializer.data)
 
         serializer = ser.BoardSerializer(result, many=True)
-        print(serializer.data)
         return response.Response(serializer.data)
 
 

--- a/gwachaepah_practice/urls.py
+++ b/gwachaepah_practice/urls.py
@@ -64,7 +64,6 @@ urlpatterns = [
     # api
     path('product/api/', views.ProductList.as_view()),
     path('board/api', views.BoardSearchList.as_view()), # 쿼리 스트링 받아서 필터링
-    path('board/api/', views.BoardList.as_view()), # 전체 보드 데이터 + 페이지네이션 get
     path('post/api/', views.PostCreateView.as_view()), # post POST
     path('post/api/<int:pk>/', views.PostDetailView.as_view()), # 특정 포스트의 get put(+patch) delete
     path('comment/api/list/<int:pk>/', views.CommentList.as_view()), # 특정 post(pk)의 comments GET


### PR DESCRIPTION
- 게시판 페이지에서 post 별로 작성자 정보를 user_key 로 받는데, 이 때 int 형의 pk 만 response 되어서 프론트에서 username 을 출력할 수 없었다.
- BoardSerializer 와 PostSerializer 를 수정하여 post obj 마다 user_key 에 해당하는 username 도 str 타입으로 추가로 보내주기로 함.
- board 페이지와 post 페이지에서 댓글 수 정보도 띄우고싶다고 요청하여 위와 같은 방법으로 comment_cnt 필드도 추가하여 response 하기로 하였다