### PR TITLE
Fix: return ImageField in Post model

### DIFF
--- a/board/models.py
+++ b/board/models.py
@@ -42,7 +42,7 @@ class Post(models.Model):
 
     title = models.CharField(max_length=100)
     content = models.TextField()
-    image1 = models.ImageField(upload_to=post_directory_path, blank=True, null=True)
+    image1 = models.ImageField(upload_to=post_directory_path)
     image2 = models.ImageField(upload_to=post_directory_path, blank=True, null=True)
     image3 = models.ImageField(upload_to=post_directory_path, blank=True, null=True)
     view_count = models.PositiveIntegerField(default=0)


### PR DESCRIPTION
- 프론트의 작업을 위해 `blank=True, null=True`였던 Post의 ImageField를 다시 필수로 지정하기 위한 작업을 하였습니다