### PR TITLE
Modify: add more filter condition in search price list

### DIFF
--- a/board/views.py
+++ b/board/views.py
@@ -245,9 +245,16 @@ class SearchList(views.APIView):
     @swagger_auto_schema(manual_parameters=[search_param])
     def get(self, request):
         search_text = request.GET['search']
-        search_res = OpenApi.objects.filter(Q(item_name=search_text) | Q(kind_name__startswith=search_text))
-        result = search_res.exclude(price="-").order_by('-id')
-        serializer = ser.SearchSerializer(result, many=True)
+        queryset = OpenApi.objects.filter(item_name=search_text)
+        if (not search_text.isalpha()) or ("g" in search_text):
+            serializer = ser.SearchSerializer(queryset, many=True)
+            return response.Response(serializer.data)
+        if not len(queryset):
+            queryset = OpenApi.objects.filter(kind_name__startswith=search_text)
+        if not len(queryset):
+            queryset = OpenApi.objects.filter(kind_name__contains=search_text)
+        queryset.exclude(price="-").order_by('-id')
+        serializer = ser.SearchSerializer(queryset, many=True)
         return response.Response(serializer.data)
 
 


### PR DESCRIPTION
- `무` 로 검색했을 때 `당근 - 무세척` 이 나오는 케이스 발견
- space 만 넣어 검색했을 때 `흰 콩`등 space 가 추가되어있는 모든 데이터가 출력된다
- 품목에 검색어와 동일한 데이터가 있는 경우에는 해당 데이터를 response 하고, 품목에 검색어와 동일한 케이스가 없는 경우에만 품종에서 추가로 검색하는 방법으로 필터링한다.
- 검색어가 한글/영문이 아닌경우를 필터링하여 해당 케이스에는 빈 데이터가 response 되도록 한다
- 검색어 중 'g' 가 있는 경우 품종에 '100g' 등의 unit 정보가 있는 경우에도 검색되는 케이스가 발견되었다.
- 검색어에 'g' 가 포함된 경우에도 빈 데이터가 response 되도록 셋팅하였다