### PR TITLE
Modify: add set_profile and remove signal in models

### DIFF
--- a/board/models.py
+++ b/board/models.py
@@ -16,13 +16,6 @@ class Profile(models.Model):
     region = models.PositiveIntegerField(default=0)
 
 
-@receiver(post_save, sender=User)
-def update_user_profile(sender, instance, created, **kwargs):
-    if created:
-        Profile.objects.create(user_key=instance)
-    instance.profile.save()
-
-
 class AutoDateTimeField(models.DateTimeField):
     def pre_save(self, model_instance, add):
         return timezone.now()

--- a/board/views.py
+++ b/board/views.py
@@ -16,7 +16,7 @@ from rest_framework_simplejwt.views import TokenObtainPairView
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 
-from .models import Post, Comment, Product, OpenApi
+from .models import Post, Comment, Product, OpenApi, Profile
 from .forms import PostForm, CommentForm, LoginForm, RegisterForm
 
 from . import serializers as ser
@@ -316,6 +316,11 @@ class UserRegisterView(generics.CreateAPIView):
     queryset = User.objects.all()
     serializer_class = ser.RegisterSerializer
 
+    def set_profile(self, user_obj, region):
+        profile = Profile.objects.create(user_key=user_obj)
+        profile.region = region["region"]
+        profile.save()
+
     def post(self, request, *args, **kwargs):
         user = request.data["user"]
         region = request.data["region"]
@@ -326,8 +331,6 @@ class UserRegisterView(generics.CreateAPIView):
             )
             user_obj.set_password(user["password"])
             user_obj.save()
-            user_obj.refresh_from_db()
-            user_obj.profile.region = region["region"]
-            user_obj.save()
+            self.set_profile(user_obj, region)
             return response.Response(user_serializer.data, status=status.HTTP_201_CREATED)
         return response.Response(user_serializer.errors, status=status.HTTP_418_IM_A_TEAPOT)


### PR DESCRIPTION
- 기존에는 User table과 Profile table를 연결하는데, signal을 사용했었다.
- '의도를 명확하게 드러내라'는 멘토님의 조언으로 `UserRegisterView` 에서 해당 함수를 가져다 쓰는 것을 시도했다.
- `set_profile`이라는 함수를 만들어, 기존의 User 에서 Profile object를 생성하고, 그 object에 region을 넣어주는 방법으로 진행하였다.