### PR TITLE
Modify: CORS settings

### DIFF
--- a/gwachaepah_practice/settings.py
+++ b/gwachaepah_practice/settings.py
@@ -192,4 +192,9 @@ SIMPLE_JWT = {
     'SLIDING_TOKEN_REFRESH_LIFETIME': timedelta(days=1),
 }
 
-CORS_ORIGIN_ALLOW_ALL = True
+CORS_ALLOWED_ORIGINS = [
+    "http://127.0.0.1:8000",
+    "http://127.0.0.1:8080",
+    "https://jecheol-42.herokuapp.com",
+    "https://jecheol42.herokuapp.com"
+]


### PR DESCRIPTION
- api에 아무나 접근하지 못하게 하기 위해서, CORS 설정을 바꿨다.
- 모든 사람이 접근할 수 있는 `CORS_ORIGIN_ALLOW_ALL = True`에서 프론트와 백엔드 로컬 주소, heroku 주소 총 4개만을 추가했다.