### PR TITLE
Feat: add api authentication setting

### DIFF
--- a/board/views.py
+++ b/board/views.py
@@ -9,7 +9,7 @@ from django.contrib.auth.models import User
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import render, redirect, get_object_or_404
 
-from rest_framework import generics, views, response, status
+from rest_framework import generics, views, response, status, permissions
 from rest_framework.parsers import MultiPartParser
 from rest_framework_simplejwt.views import TokenObtainPairView
 
@@ -145,6 +145,7 @@ class ProductList(generics.ListAPIView):
 class BoardSearchList(generics.ListAPIView):
     queryset = Post.objects.all()
     serializer_class = ser.BoardSerializer
+    permission_classes = [permissions.IsAuthenticated]
 
     search_param = openapi.Parameter(
         'search',

--- a/gwachaepah_practice/settings.py
+++ b/gwachaepah_practice/settings.py
@@ -156,6 +156,7 @@ DEFAULT_FILE_STORAGE = 'cloudinary_storage.storage.MediaCloudinaryStorage'
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': [
         'rest_framework_simplejwt.authentication.JWTAuthentication',
+        'rest_framework.authentication.SessionAuthentication',
     ],
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
     'PAGE_SIZE': 12

--- a/gwachaepah_practice/urls.py
+++ b/gwachaepah_practice/urls.py
@@ -14,7 +14,7 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 from django.conf.urls import url
 
 from board import views
@@ -84,5 +84,7 @@ urlpatterns = [
     # jwt
     path('token/api/', views.MyTokenObtainPairView.as_view(), name='token_obtain_pair'),
     path('token/api/refresh/', jwt_views.TokenRefreshView.as_view(), name='token_refresh'),
-    path('token/api/verify/', jwt_views.TokenVerifyView.as_view(), name='token_verify')
+    path('token/api/verify/', jwt_views.TokenVerifyView.as_view(), name='token_verify'),
+
+    path('api-auth/', include('rest_framework.urls')),
 ]


### PR DESCRIPTION
- api에 url로 직접 접속했을 때, 관리자가 아니면 볼 수 없게 했다.
- root 계정으로 로그인해야 `GET`, `POST`, `PUT`, `DELETE` 등이 가능하다.
- 여기서는 JWT로 로그인하지 않고, Session으로 로그인하기 때문에 Session을 `DEFAULT_AUTHENTICATION_CLASSES`에 추가해야 했다.

<img width="934" alt="스크린샷 2021-11-19 오후 9 44 49" src="https://user-images.githubusercontent.com/61774034/142625017-cc159bd8-c593-41ca-ba19-eb89328d3d44.png">

<img width="938" alt="스크린샷 2021-11-19 오후 9 45 28" src="https://user-images.githubusercontent.com/61774034/142625059-9c3521c9-96f8-4b0a-993e-a2e0fb7ec8b9.png">
