### PR TITLE
Modify: add allow request url

### DIFF
--- a/board/views.py
+++ b/board/views.py
@@ -182,10 +182,10 @@ class BoardSearchList(generics.ListAPIView):
         except:
             return response.Response(status=status.HTTP_403_FORBIDDEN)
         front = "https://jecheol42.herokuapp.com/"
+        swagger = "https://jecheol-42.herokuapp.com/swagger/"
         local = "http://127.0.0.1:8000/swagger/"
-        if (origin != front) and (origin != local):
-                return response.Response(status=status.HTTP_418_IM_A_TEAPOT)
-        self.permission_classes = [permissions.IsAuthenticated]
+        if not ((origin == front) or (origin == swagger) or (origin == local)):
+            return response.Response(status=status.HTTP_418_IM_A_TEAPOT)
 
         search_res = self.get_search(request)
         result = self.get_tag(request, search_res)


### PR DESCRIPTION
- request header 에 referer 가 없는 경우 403 에러를 보낸다 (브라우저에 직접 api url 를 입력한 경우)
- 프론트 서버, swagger, 로컬 swagger 에서 request 를 보낸 경우에만 데이터를 보내고 그 외에는 418 에러를 보내도록 셋팅하였다