### PR TITLE
Modify: set custom permission classes in several cases

### DIFF
--- a/board/views.py
+++ b/board/views.py
@@ -175,18 +175,21 @@ class BoardSearchList(generics.ListAPIView):
             return search_res.exclude(tag=2)
         return search_res.filter(tag=tag_type)
 
+    def get_permissions(self):
+        try:
+            origin = self.request.META['HTTP_REFERER']
+        except:
+            permission_classes = [permissions.IsAdminUser,]
+        else:
+            front = "https://jecheol42.herokuapp.com/"
+            if (origin == front):
+                permission_classes = [permissions.AllowAny]
+            else:
+                permission_classes = [permissions.IsAdminUser, ]
+        return [permission() for permission in permission_classes]
+
     @swagger_auto_schema(manual_parameters=[search_param, tag_param])
     def get(self, request, *args, **kwargs):
-        try:
-            origin = request.META['HTTP_REFERER']
-        except:
-            return response.Response(status=status.HTTP_403_FORBIDDEN)
-        front = "https://jecheol42.herokuapp.com/"
-        swagger = "https://jecheol-42.herokuapp.com/swagger/"
-        local = "http://127.0.0.1:8000/swagger/"
-        if not ((origin == front) or (origin == swagger) or (origin == local)):
-            return response.Response(status=status.HTTP_418_IM_A_TEAPOT)
-
         search_res = self.get_search(request)
         result = self.get_tag(request, search_res)
         page = self.paginate_queryset(result)


### PR DESCRIPTION
- 브라우저에 api url 을 입력한 경우에도 에러가 아닌 스태프 권한 로그인이 된 경우에만 데이터를 볼 수 있도록 셋팅을 바꾸었다.
- url 에 대한 permission_classes 를 셋팅하는데, request 에 referer 가 있는지 확인하고, 없는 경우(브라우저에서 직접 입력하여 접근) 스태프 로그인이 된 경우에만 데이터 볼 수 있도록 조건문 처리하였다
- referer 가 있는 경우에도 프론트에서 요청한 경우가 아니라면 스태프 권한으로 로그인 된 경우에만 데이터를 볼 수 있도록 셋팅하였다
- referer 가 프론트 서버와 같은 경우에는 allowany 로 셋팅하고, 그 외의 경우에는 스태프 권한 확인하도록 하였다.