### PR TITLE
Feat: django login/out in swagger

### DIFF
--- a/gwachaepah_practice/settings.py
+++ b/gwachaepah_practice/settings.py
@@ -162,6 +162,12 @@ REST_FRAMEWORK = {
     'PAGE_SIZE': 12
 }
 
+SWAGGER_SETTINGS = {
+    'USE_SESSION_AUTH': True,
+    'LOGIN_URL': '/api-auth/login/',
+    'LOGOUT_URL': '/api-auth/logout/',
+}
+
 SIMPLE_JWT = {
     'ACCESS_TOKEN_LIFETIME': timedelta(minutes=5),
     'REFRESH_TOKEN_LIFETIME': timedelta(days=1),


### PR DESCRIPTION
- swagger 에서 django login 버튼을 눌렀을 때 에러가 발생한다.
- swagger 기본 셋팅으로 django login 버튼을 누르면 ~/accounts/login/ 으로 이동하여 장고 로그인을 수행하는데
- 장고와 yasg 둘 중 어디의 문제인지 모르겠지만 우리는 drf 를 쓰고있으므로 drf 로그인을 하려면 ~/api-auth/login/으로 이동해야한다.
- 이를 위해서 settings.py 에 swagger_setting 을 추가하여 기본값을 변경하였다.
- 이후 테스트에서 브라우저에 url 넣은 경우와 swagger 에서 테스트하는 경우 모두 동일하게 동작하는 것을 확인했다.